### PR TITLE
Strip control inputs from graph when creating new TF functions from tensors.

### DIFF
--- a/realbook/__init__.py
+++ b/realbook/__init__.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 __author__ = "Spotify"
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __email__ = "realbook@spotify.com"
 __description__ = "Python libraries for easier machine learning on audio"
 __url__ = "https://github.com/spotify/realbook"

--- a/realbook/layers/compatibility.py
+++ b/realbook/layers/compatibility.py
@@ -276,9 +276,7 @@ def create_function_from_tensors(
         # If this graph has any control inputs in it, those inputs will
         # likely not be convertible (nor do we want them in our converted model!)
         for node in graph_def.node:
-            node.input[:] = [
-                tensor_name for tensor_name in node.input if not tensor_name.startswith("^")
-            ]
+            node.input[:] = [tensor_name for tensor_name in node.input if not tensor_name.startswith("^")]
 
     try:
         return _load_concrete_function_from_graph_def(

--- a/realbook/layers/compatibility.py
+++ b/realbook/layers/compatibility.py
@@ -21,7 +21,7 @@ from google.protobuf.json_format import (
     MessageToDict as SerializeProtobufToDict,
     ParseDict as ParseDictToProtobuf,
 )
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, cast, Dict, List, Optional, Tuple, Union
 from tensorflow.python.framework.convert_to_constants import (
     convert_variables_to_constants_v2_as_graph,
 )
@@ -355,4 +355,4 @@ def dump_saved_model_to_graph(
         for node in graph_def.node:
             node.input[:] = [tensor_name for tensor_name in node.input if not tensor_name.startswith("^")]
 
-    return graph_def.SerializeToString()
+    return cast(bytes, graph_def.SerializeToString())

--- a/realbook/layers/compatibility.py
+++ b/realbook/layers/compatibility.py
@@ -277,9 +277,7 @@ def create_function_from_tensors(
         # If this graph has any control inputs in it, those inputs will
         # likely not be convertible (nor do we want them in our converted model!)
         for node in graph_def.node:
-            node.input[:] = [
-                tensor_name for tensor_name in node.input if not is_control_input(tensor_name)
-            ]
+            node.input[:] = [tensor_name for tensor_name in node.input if not is_control_input(tensor_name)]
 
     try:
         return _load_concrete_function_from_graph_def(
@@ -356,8 +354,6 @@ def dump_saved_model_to_graph(
         # If this graph has any control inputs in it, those inputs will
         # likely not be convertible (nor do we want them in our converted model!)
         for node in graph_def.node:
-            node.input[:] = [
-                tensor_name for tensor_name in node.input if not is_control_input(tensor_name)
-            ]
+            node.input[:] = [tensor_name for tensor_name in node.input if not is_control_input(tensor_name)]
 
     return cast(bytes, graph_def.SerializeToString())

--- a/tests/layers/test_compatibility.py
+++ b/tests/layers/test_compatibility.py
@@ -301,7 +301,7 @@ def test_create_function_from_tensors(include_control_inputs: bool) -> None:
 
     with keras_model_to_savedmodel(model) as saved_model_path:
         tensors = get_all_tensors_from_saved_model(saved_model_path)
-        control_inputs = sum([op.control_inputs for op in set([t.op for t in tensors])], [])
+        control_inputs: List[tf.Operation] = sum([op.control_inputs for op in set([t.op for t in tensors])], [])
         assert control_inputs
         fun = create_function_from_tensors(tensors[0], tensors[-1], include_control_inputs=include_control_inputs)
         control_inputs_in_graph = [node.name for node in fun.graph.as_graph_def().node if is_control_input(node.name)]

--- a/tests/layers/test_compatibility.py
+++ b/tests/layers/test_compatibility.py
@@ -285,6 +285,6 @@ def test_tensor_wrapper_layer_multiple_inputs() -> None:
         tensors = get_all_tensors_from_saved_model(saved_model_path)
         layer = TensorWrapperLayer(tensors[0].graph.inputs, tensors[0].graph.outputs)
 
-    outputs = layer([value for _name, value in sorted(x.items(), key=lambda t: t[0])])  # type: ignore
+    outputs = layer([value for _name, value in sorted(x.items(), key=lambda t: t[0])])
     for expected, actual in zip(expected_outputs, outputs):
         assert np.allclose(actual, expected)


### PR DESCRIPTION
When using `create_function_from_tensors` to create a new TensorFlow function from an existing TF model or graph, the presence of control inputs can cause the extraction of a sub-graph to fail. These control inputs are generally only used during training, while this function is usually used for inference.

This PR adds a new argument to `create_function_from_tensors` to allow including control inputs, which are now omitted by default. To detect control inputs, we use [the same criteria as the main TensorFlow package](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/importer.py#L34-L36).